### PR TITLE
feat: migrate config file to .mskills/ directory

### DIFF
--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -13,10 +13,15 @@ vi.mock('node:os', () => ({
 
 describe('Config', () => {
   const mockHomeDir = '/mock/home';
-  const mockConfigPath = path.join(mockHomeDir, '.mskills.json');
+  const mockConfigDir = path.join(mockHomeDir, '.mskills');
+  const mockConfigPath = path.join(mockConfigDir, 'config.json');
+  const mockOldConfigPath = path.join(mockHomeDir, '.mskills.json');
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fs.stat).mockRejectedValue({ code: 'ENOENT' });
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.rename).mockResolvedValue(undefined);
   });
 
   describe('loadConfig', () => {
@@ -35,6 +40,18 @@ describe('Config', () => {
       const config = await loadConfig();
 
       expect(config).toEqual(mockConfig);
+    });
+
+    it('should migrate old config if it exists', async () => {
+      const mockConfig = { skills: { test: { path: '/path' } }, agents: ['claude'] };
+      // Old file exists
+      vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true } as any);
+      // New file doesn't exist yet but let's assume migrate moves it
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(mockConfig));
+
+      await loadConfig();
+
+      expect(fs.rename).toHaveBeenCalledWith(mockOldConfigPath, mockConfigPath);
     });
   });
 


### PR DESCRIPTION
This PR consolidates the configuration file into the central management directory to clean up the user's home directory and follow modern CLI conventions.

Previously, mskills used both ~/.mskills.json (file) and ~/.mskills/ (directory). This change moves the configuration file inside the directory.