### PR TITLE
switch to googleapis/release-please-action and add debug log

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,13 @@ jobs:
       pull-requests: write
       id-token: write # Required for Trusted Publishing
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: node
+
+      - name: Debug release-please outputs
+        run: echo "release_created=${{ steps.release.outputs.release_created }}"
 
       # Publish to npm when a release is created
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases by switching to the maintained `googleapis/release-please-action` and adds a debugging step to help verify release creation.

Workflow maintenance:

* Updated the release action from `google-github-actions/release-please-action@v4` to `googleapis/release-please-action@v4` to use the currently maintained version.

Debugging improvements:

* Added a step to echo the `release_created` output for easier debugging of the release process.