### PR TITLE
refactor: separate publish job to individual workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for Trusted Publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,29 +18,3 @@ jobs:
         id: release
         with:
           release-type: node
-
-      - name: Debug release-please outputs
-        run: echo "release_created=${{ steps.release.outputs.release_created }}"
-
-      # Publish to npm when a release is created
-      - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.release_created }}
-
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
-        if: ${{ steps.release.outputs.release_created }}
-        with:
-          node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm ci
-
-      - name: Build
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm run build
-
-      - name: Publish to npm
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --provenance --access public


### PR DESCRIPTION
This pull request updates the release workflow to use a dedicated publish workflow for npm publishing, simplifying the release process and improving separation of concerns.

**Workflow improvements:**

* Added a new workflow file, `.github/workflows/publish.yml`, that handles npm publishing when a release is published, including steps for checkout, Node.js setup, dependency installation, build, and publish.
* Removed npm publishing steps from `.github/workflows/release.yml`, so releases no longer trigger npm publishing directly in the release workflow.