### PR TITLE
update README with configuration path info and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,15 @@ This will create symbolic links (default) or copies of your skills in the agent'
 | `mskills agents add <names...>` | Enable target agents. |
 | `mskills agents remove <names...>` | Disable target agents. |
 | `mskills agents list` | List enabled agents. |
-| `mskills agents list` | List enabled agents. |
 | `mskills apply` | Apply skills to enabled agents. |
 | `mskills apply --force` | Force overwrite existing skills. |
+
+## Configuration
+
+**mskills** stores its configuration and data in the following directory:
+
+- **Config File**: `~/.mskills/config.json`
+- **Internal Skills Cache**: `~/.mskills/skills` (used for internal management)
 
 ## Supported Agents
 


### PR DESCRIPTION
This pull request updates the `README.md` file to add new documentation about configuration and data storage for **mskills**. The main change is the addition of a section that clearly describes where the tool stores its configuration file and internal skills cache.

Documentation improvements:

* Added a "Configuration" section to the `README.md` to document the locations of the config file (`~/.mskills/config.json`) and the internal skills cache (`~/.mskills/skills`).