### PR TITLE
feat: allow mskills update to infer skill name from path

### DIFF
--- a/.changeset/empty-pugs-shake.md
+++ b/.changeset/empty-pugs-shake.md
@@ -1,0 +1,5 @@
+---
+"mskills": patch
+---
+
+feat: allow mskills update to infer skill name from path

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This will output an XML block like:
 | Command | Description |
 | :--- | :--- |
 | `mskills add <source> [name]` | Add a skill from GitHub or local path. |
-| `mskills update <name> [source]` | Update an added skill. |
+| `mskills update <name_or_path> [source]` | Update an added skill. |
 | `mskills remove <names...>` | Remove registered skills. |
 | `mskills list` | List registered skills. |
 | `mskills export config [outPath]` | Export mskills configuration as a zip file. |

--- a/src/skills/manager.ts
+++ b/src/skills/manager.ts
@@ -63,16 +63,35 @@ export class SkillManager {
 
   async update(name: string, source?: string) {
     const config = await loadConfig();
-    const skillConfig = config.skills[name];
+    
+    let targetName = name;
+    let actualSource = source;
+
+    if (!config.skills[targetName] && !source && (name.includes('/') || name.includes('\\'))) {
+      let inferredName: string;
+      if (isGitUrl(name)) {
+        const pathParts = name.replace(/\/+$/, '').split('/');
+        inferredName = pathParts[pathParts.length - 1].replace(/\.git$/, '');
+      } else {
+        inferredName = path.basename(name.replace(/\/+$/, ''));
+      }
+      
+      if (config.skills[inferredName]) {
+        targetName = inferredName;
+        actualSource = name;
+      }
+    }
+
+    const skillConfig = config.skills[targetName];
     if (!skillConfig) {
       throw new Error(`Skill '${name}' not found.`);
     }
 
     const currentPath = skillConfig.path;
 
-    if (source) {
-      if (isGitUrl(source)) {
-        if (skillConfig.sourceUrl === source) {
+    if (actualSource) {
+      if (isGitUrl(actualSource)) {
+        if (skillConfig.sourceUrl === actualSource) {
           // Check if it's a standard git repo (has .git)
           const gitDir = path.join(currentPath, '.git');
           try {
@@ -81,18 +100,18 @@ export class SkillManager {
           } catch {
              // No .git directory, implies subdirectory install or other non-git structure. Re-install.
              await fs.rm(currentPath, { recursive: true, force: true });
-             await installFromGit(source, currentPath);
+             await installFromGit(actualSource, currentPath);
           }
         } else {
           // New Source URL - Reinstall
           await fs.rm(currentPath, { recursive: true, force: true });
-          await installFromGit(source, currentPath);
-          skillConfig.sourceUrl = source;
+          await installFromGit(actualSource, currentPath);
+          skillConfig.sourceUrl = actualSource;
           await saveConfig(config);
         }
       } else {
         // Local source
-        const absolutePath = path.resolve(source);
+        const absolutePath = path.resolve(actualSource);
         await validateSkill(absolutePath);
         // Clear directory before copying to ensure clean update? 
         // Or just copy over? fs.cp overwrites.
@@ -118,7 +137,7 @@ export class SkillManager {
              await installFromGit(skillConfig.sourceUrl, currentPath);
           }
       } else {
-        throw new Error(`Original source path for '${name}' is not stored. Please provide a path or URL to update from.`);
+        throw new Error(`Original source path for '${targetName}' is not stored. Please provide a path or URL to update from.`);
       }
     }
     


### PR DESCRIPTION
mskills update コマンドにて、引数がパス1つのみだった場合にスキル名を自動推論し、指定されたパスをアップデート元として扱う処理を追加しました。
これにより、mskills add のように直感的にパスを指定するだけでアップデートが可能になります。

また、それに伴い README.md のコマンドリファレンスを更新しました。