### PR TITLE
fix: remove failing npm install step from release workflow

### DIFF
--- a/.changeset/bright-lemons-nail.md
+++ b/.changeset/bright-lemons-nail.md
@@ -1,0 +1,5 @@
+---
+"mskills": patch
+---
+
+fix: remove failing npm install step from release workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           node-version: 22.x
 
-      - name: Install latest npm
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
node 22.x 環境で `npm install -g npm@latest` を実行するとモジュール解決エラーでリリースアクションが失敗する不具合を修正しました。