### PR TITLE
fix(ci): restore registry-url to setup-node for OIDC publishing

### DIFF
--- a/.changeset/ninety-weeks-happen.md
+++ b/.changeset/ninety-weeks-happen.md
@@ -1,0 +1,5 @@
+---
+"mskills": patch
+---
+
+fix(ci): restore registry-url to setup-node for OIDC publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
 
 
       - name: Install dependencies


### PR DESCRIPTION
Fixes the `ENEEDAUTH` error during release by restoring the `registry-url` option to `actions/setup-node`. This enables GitHub Actions to properly configure `.npmrc` so that changesets can use npm's trusted publishing (OIDC) correctly without requiring a manual npm bump to v11.