### PR TITLE
fix(ci): downgrade runner to node 20 to fix npm install and OIDC publish

### DIFF
--- a/.changeset/strange-humans-hope.md
+++ b/.changeset/strange-humans-hope.md
@@ -1,0 +1,5 @@
+---
+"mskills": patch
+---
+
+fix(ci): downgrade runner to node 20 to fix npm install and OIDC publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 22.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
+          node-version: 20.x
+
+      - name: Install latest npm
+        run: npm install -g npm@latest
 
 
       - name: Install dependencies


### PR DESCRIPTION
This pull request updates the Node.js version used in the release workflow and ensures the latest version of npm is installed. These changes help maintain compatibility and stability in the CI/CD pipeline.

Workflow environment updates:

* Changed Node.js version from 22.x to 20.x in the `.github/workflows/release.yml` workflow to align with supported Node.js releases.
* Added a step to install the latest version of npm globally after setting up Node.js, ensuring the build uses the most up-to-date npm features and fixes.Node 22 hostedtoolcache has a broken npm build that causes promise-retry errors during self-upgrade. By downgrading to Node 20, we can safely upgrade npm and rely on changesets' native OIDC authentication securely.